### PR TITLE
docker: build an image with proper permissions [WIP]

### DIFF
--- a/docker/init.sh
+++ b/docker/init.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# shellcheck shell=bash
+
+sudo -u postgres /bin/initdb --locale=C -D /data
+sudo -u postgres ln -s /etc/postgresql.conf /data/postgresql.conf
+sudo -u postgres /bin/postgres -p 5432 -D /data

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,14 @@
+Docker images are pushed to `ghcr.io` on every commit. Try the following:
+
+```
+docker run --rm -it ghcr.io/supabase/nix-postgres-15:latest
+```
+
+Every Docker image that is built on every push is given a tag that exactly
+corresponds to a Git commit in the repository &mdash; for example commit
+[d3e0c39d34e1bb4d37e058175a7bc376620f6868](https://github.com/supabase/nix-postgres/commit/d3e0c39d34e1bb4d37e058175a7bc376620f6868)
+in this repository has a tag in the container registry which can be used to pull
+exactly that version.
+
+This just starts the server. Client container images are not provided; you can
+use `nix run` for that, as outlined [here](./start-client-server.md).

--- a/tests/postgresql.conf.in
+++ b/tests/postgresql.conf.in
@@ -57,10 +57,7 @@
 
 # - Connection Settings -
 
-#listen_addresses = 'localhost'		# what IP address(es) to listen on;
-					# comma-separated list of addresses;
-					# defaults to 'localhost'; use '*' for all
-					# (change requires restart)
+listen_addresses = '*'		# what IP address(es) to listen on;
 #port = 5432				# (change requires restart)
 max_connections = 100			# (change requires restart)
 #superuser_reserved_connections = 3	# (change requires restart)


### PR DESCRIPTION
Summary: This migrates us back to using `buildImage` to create an image. However, it requires KVM, and thus it will not work on the existing GitHub Actions runner.

Change-Id: I3cbf2c4cdb1c15c87e95973a04ac5efa
