### PR TITLE
nix: add gdal overlay for smaller closures [WIP]

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1691916148,
-        "narHash": "sha256-DamxLt6yl1Ic1vCvgKhjObrzqwlV0pJ7334yuC5y3ew=",
+        "lastModified": 1692190437,
+        "narHash": "sha256-yJUZzmzSmDYb9ONPnMQDru66RjZgGQZRvj3tQebkexk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "750fc50bfd132a44972aa15bb21937ae26303bc4",
+        "rev": "9b2aa98db6b10503666a50f4eb93b2fc0d57bde5",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -35,6 +35,7 @@
             # want to have an arbitrary order, since it might matter. being
             # explicit is better.
             (import ./overlays/cargo-pgrx.nix)
+            (import ./overlays/gdal-small.nix)
           ];
         };
 

--- a/overlays/gdal-small.nix
+++ b/overlays/gdal-small.nix
@@ -1,0 +1,14 @@
+final: prev: {
+    # override the version of gdal used with postgis with the small version.
+    # significantly reduces overall closure size
+    gdal = prev.gdalMinimal.override {
+        /* other features can be enabled, reference:
+        https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/libraries/gdal/default.nix
+        */
+
+        # useHDF = true;
+        # useArrow = true;
+        # useLibHEIF = true;
+        # ...
+    };
+}


### PR DESCRIPTION
Summary: This will override `gdal` globally to use a smaller version. Does not properly exist upstream yet, and so it cannot be used.

Change-Id: I8a302420a84d41fc859487365fa31474