### PR TITLE
chore(deps): bump wrappers

### DIFF
--- a/ext/wrappers/Cargo.lock
+++ b/ext/wrappers/Cargo.lock
@@ -2053,9 +2053,9 @@ checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.5"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
+checksum = "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f"
 
 [[package]]
 name = "lock_api"
@@ -2329,9 +2329,9 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "openssl"
-version = "0.10.57"
+version = "0.10.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bac25ee399abb46215765b1cb35bc0212377e58a061560d8b29b024fd0430e7c"
+checksum = "79a4c6c3a2b158f7f8f2a2fc5a969fa3a068df6fc9dbb4a43845436e3af7c800"
 dependencies = [
  "bitflags 2.4.0",
  "cfg-if",
@@ -2361,9 +2361,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.92"
+version = "0.9.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db7e971c2c2bba161b2d2fdf37080177eff520b3bc044787c7f1f5f9e78d869b"
+checksum = "3812c071ba60da8b5677cc12bcb1d42989a65553772897a7e0355545a819838f"
 dependencies = [
  "cc",
  "libc",
@@ -3151,9 +3151,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.10"
+version = "0.38.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed6248e1caa625eb708e266e06159f135e8c26f2bb7ceb72dc4b2766d0340964"
+checksum = "745ecfa778e66b2b63c88a61cb36e0eea109e803b0b86bf9879fbc77c70e86ed"
 dependencies = [
  "bitflags 2.4.0",
  "errno",
@@ -4321,7 +4321,7 @@ dependencies = [
 
 [[package]]
 name = "wrappers"
-version = "0.1.16"
+version = "0.1.19"
 dependencies = [
  "arrow-array",
  "async-compression",

--- a/ext/wrappers/default.nix
+++ b/ext/wrappers/default.nix
@@ -4,14 +4,14 @@
 
 buildPgrxExtension_0_10_2 rec {
   pname = "supabase-wrappers";
-  version = "unstable-2023-10-03";
+  version = "unstable-2023-12-18";
   inherit postgresql;
 
   src = fetchFromGitHub {
     owner  = "supabase";
     repo   = "wrappers";
-    rev    = "4b64a6e55dcfae408627c5c52a3a15aecc9c56d5";
-    hash   = "sha256-nlpRkr/L4owv+ulBhD5BGPCRIkAADwtOCA0nUcABiX4=";
+    rev    = "079922e536df0f4d827a0b35fc0432e7e20c6e1c";
+    hash   = "sha256-wvsAqDk+1am6mSBCF5uzDArnbBIpLqTylLzF4VZ/p08=";
   };
 
   nativeBuildInputs = [ pkg-config ];


### PR DESCRIPTION
closes
- https://github.com/supabase/nix-postgres/security/dependabot/5
- https://github.com/supabase/nix-postgres/security/dependabot/4