### PR TITLE
fix: reconciling the Cargo.lock for wrappers to fix build

### DIFF
--- a/ext/wrappers/Cargo.lock
+++ b/ext/wrappers/Cargo.lock
@@ -2329,9 +2329,9 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "openssl"
-version = "0.10.60"
+version = "0.10.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79a4c6c3a2b158f7f8f2a2fc5a969fa3a068df6fc9dbb4a43845436e3af7c800"
+checksum = "bac25ee399abb46215765b1cb35bc0212377e58a061560d8b29b024fd0430e7c"
 dependencies = [
  "bitflags 2.4.0",
  "cfg-if",
@@ -2361,9 +2361,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.96"
+version = "0.9.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3812c071ba60da8b5677cc12bcb1d42989a65553772897a7e0355545a819838f"
+checksum = "db7e971c2c2bba161b2d2fdf37080177eff520b3bc044787c7f1f5f9e78d869b"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
## What kind of change does this PR introduce?

This project would not build locally due to Cargo.lock mismatch

This pr introduces the Cargo.lock file from the specific commit for the most current version of supabase/wrapper used in HEAD of the main branch of this project

for reference it is https://github.com/supabase/wrappers/blob/079922e536df0f4d827a0b35fc0432e7e20c6e1c/wrappers/Cargo.lock

This PR does not yet attempt to update to the latest versions of supabase/postgres and supabase/wrappers, and will ultimately submit a future PR to cover that update
