### PR TITLE
Sam/action kvm

### DIFF
--- a/.github/workflows/cache-upload.yml
+++ b/.github/workflows/cache-upload.yml
@@ -27,6 +27,9 @@ jobs:
         with:
           role-to-assume: ${{ secrets.DEV_AWS_ROLE }}
           aws-region: "us-east-1"
+          kvm: true
+          extra-conf: |
+            system-features = kvm
 
       - name: write secret key
         # use python so we don't interpolate the secret into the workflow logs, in case of bugs

--- a/ext/wrappers/Cargo.lock
+++ b/ext/wrappers/Cargo.lock
@@ -2329,9 +2329,9 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "openssl"
-version = "0.10.60"
+version = "0.10.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79a4c6c3a2b158f7f8f2a2fc5a969fa3a068df6fc9dbb4a43845436e3af7c800"
+checksum = "bac25ee399abb46215765b1cb35bc0212377e58a061560d8b29b024fd0430e7c"
 dependencies = [
  "bitflags 2.4.0",
  "cfg-if",
@@ -2361,9 +2361,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.96"
+version = "0.9.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3812c071ba60da8b5677cc12bcb1d42989a65553772897a7e0355545a819838f"
+checksum = "db7e971c2c2bba161b2d2fdf37080177eff520b3bc044787c7f1f5f9e78d869b"
 dependencies = [
  "cc",
  "libc",

--- a/flake.nix
+++ b/flake.nix
@@ -214,6 +214,7 @@
                 dockerTools.binSh sudo postgresqlConfig
               ];
               pathsToLink = [ "/bin" "/etc" "/var" "/share" ];
+              buildInputs = [ pkgs.qemu ];
             };
 
             config = {
@@ -347,8 +348,7 @@
           # set can go here.
           inherit (pkgs)
             # NOTE: comes from our cargo-pgrx.nix overlay
-            cargo-pgrx_0_10_2
-            ;
+            cargo-pgrx_0_10_2;
         };
 
         # The list of exported 'checks' that are run with every run of 'nix


### PR DESCRIPTION
## What kind of change does this PR introduce?

trying to turn on kvm features so that gh action will complete successfully (changing permission on /dev/kvm worked locally on linux machine)

## What is the current behavior?

We are using `buildImage` to build docker images, which in turn uses a qemu-kvm machine to perform the build.

Github actions cannot access kvm on the build machine to perform a build

## What is the new behavior?

Adding options to the nix installer action to attempt to turn on kvm

