### PR TITLE
Sam/nix2container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ result*
 
 # shell history
 .history
+container.sh

--- a/docker/init.sh.in
+++ b/docker/init.sh.in
@@ -1,6 +1,5 @@
 #!/bin/bash
 # shellcheck shell=bash
-
-sudo -u postgres /bin/initdb --locale=C -D /data
-sudo -u postgres ln -s /etc/postgresql.conf /data/postgresql.conf
-sudo -u postgres /bin/postgres -p @PGSQL_DEFAULT_PORT@ -D /data
+/bin/initdb --locale=C -D /data/postgresql
+ln -s /etc/postgresql.conf /data/postgresql/postgresql.conf
+/bin/postgres -p @PGSQL_DEFAULT_PORT@ -D /data/postgresql 

--- a/flake.lock
+++ b/flake.lock
@@ -18,7 +18,59 @@
         "type": "github"
       }
     },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nix2container": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1703410130,
+        "narHash": "sha256-qbJQ8DtdKzFK0fZck7kX64QWkS/3tKefxGjyI+SAQa4=",
+        "owner": "nlewo",
+        "repo": "nix2container",
+        "rev": "6aa8491e73843ac8bf714a3904a45900f356ea44",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nlewo",
+        "repo": "nix2container",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
+      "locked": {
+        "lastModified": 1697269602,
+        "narHash": "sha256-dSzV7Ud+JH4DPVD9od53EgDrxUVQOcSj4KGjggCDVJI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9cb540e9c1910d74a7e10736277f6eb9dff51c81",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
       "locked": {
         "lastModified": 1696261572,
         "narHash": "sha256-s8TtSYJ1LBpuITXjbPLUPyxzAKw35LhETcajJjCS5f0=",
@@ -37,10 +89,26 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nix2container": "nix2container",
+        "nixpkgs": "nixpkgs_2"
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",


### PR DESCRIPTION
## What kind of change does this PR introduce?

refactoring docker image build to use https://github.com/nlewo/nix2container

## What is the current behavior?

builtin nixpkgs dockerTools pushes the entire image tar into the nix store, which takes up a huge amount of space

## What is the new behavior?

nix2container is smarter about build/rebuild of layers + builds an artifact which describes a container layer with a list of Nix store paths.
