### PR TITLE
fix: cache upload action needs versions bumped

### DIFF
--- a/.github/workflows/cache-upload.yml
+++ b/.github/workflows/cache-upload.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: build and copy to S3
         run: |
-          for x in 14 15; do
+          for x in 15 16; do
             nix build .#psql_$x/bin -o result-$x
           done
           nix copy --to s3://nix-postgres-artifacts?secret-key=nix-secret-key ./result*


### PR DESCRIPTION
## What kind of change does this PR introduce?

just needed to bump versions so that cache upload works properly again