### PR TITLE
Orioledb

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,8 +26,11 @@ jobs:
 
       - name: Build images
         run: |
-          nix build .#psql_14/docker -o result-docker-14
           nix build .#psql_15/docker -o result-docker-15
+          nix build .#psql_16/docker -o result-docker-16
+          nix build .#psql_orioledb_16/docker -o result-docker-orioledb-16
+          
+
 
       - name: Tag images
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ sbom.csv
 graph*.png
 init.sh
 postgres*
+build.log

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ sbom.spdx.json
 sbom.cdx.json
 sbom.csv
 graph*.png
+init.sh
+postgres*

--- a/ext/orioledb.nix
+++ b/ext/orioledb.nix
@@ -12,17 +12,19 @@ stdenv.mkDerivation rec {
   version = "patches16_23";
   buildInputs = [ curl libkrb5 postgresql python3 openssl ];
   buildPhase = "make USE_PGXS=1 ORIOLEDB_PATCHSET_VERSION=23";
-
   installPhase = ''
+    runHook preInstall
     mkdir -p $out/{lib,share/postgresql/extension}
 
     cp *.so      $out/lib
     cp *.sql     $out/share/postgresql/extension
     cp *.control $out/share/postgresql/extension
+        
+    runHook postInstall
   '';
   doCheck = true;
   meta = with lib; {
-    description = "Orioledb";
+    description = "orioledb";
     maintainers = with maintainers; [ samrose ];
     platforms = postgresql.meta.platforms;
     license = licenses.postgresql;

--- a/ext/orioledb.nix
+++ b/ext/orioledb.nix
@@ -1,0 +1,30 @@
+{lib, stdenv, fetchFromGitHub, curl, libkrb5, postgresql, python3, openssl}:
+
+stdenv.mkDerivation rec {
+  pname = "orioledb";
+  name = pname;
+  src = fetchFromGitHub {
+    owner = "orioledb";
+    repo = "orioledb";
+    rev = "main";
+    sha256 = "sha256-QbDp9S8JXO66sfaHZIQ3wFCVRxsAaaNSRgC6hvL3EKY=";
+  };
+  version = "patches16_23";
+  buildInputs = [ curl libkrb5 postgresql python3 openssl ];
+  buildPhase = "make USE_PGXS=1 ORIOLEDB_PATCHSET_VERSION=23";
+
+  installPhase = ''
+    mkdir -p $out/{lib,share/postgresql/extension}
+
+    cp *.so      $out/lib
+    cp *.sql     $out/share/postgresql/extension
+    cp *.control $out/share/postgresql/extension
+  '';
+  doCheck = true;
+  meta = with lib; {
+    description = "Orioledb";
+    maintainers = with maintainers; [ samrose ];
+    platforms = postgresql.meta.platforms;
+    license = licenses.postgresql;
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -72,11 +72,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1708847675,
-        "narHash": "sha256-RUZ7KEs/a4EzRELYDGnRB6i7M1Izii3JD/LyzH0c6Tg=",
+        "lastModified": 1709386671,
+        "narHash": "sha256-VPqfBnIJ+cfa78pd4Y5Cr6sOWVW8GYHRVucxJGmRf8Q=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2a34566b67bef34c551f204063faeecc444ae9da",
+        "rev": "fa9a51752f1b5de583ad5213eb621be071806663",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -75,7 +75,7 @@
           "pgjwt"
           "plpgsql_check"
           "pg_safeupdate"
-          "timescaledb"
+          /*"timescaledb"*/
           "wal2json"
           /* pljava */
           "rum"
@@ -387,6 +387,7 @@
                 --subst-var-by 'PGSQL_SUPERUSER' '${pgsqlSuperuser}' \
                 --subst-var-by 'PSQL15_BINDIR' '${basePackages.psql_15.bin}' \
                 --subst-var-by 'PSQL16_BINDIR' '${basePackages.psql_16.bin}' \
+                --subst-var-by 'PSQLORIOLEDB16_BINDIR' '${basePackages.psql_orioledb_16.bin}' \
                 --subst-var-by 'PSQL_CONF_FILE' '${configFile}' \
                 --subst-var-by 'PGSODIUM_GETKEY' '${getkeyScript}'
 
@@ -400,7 +401,8 @@
               --subst-var-by 'PGSQL_DEFAULT_PORT' '${pgsqlDefaultPort}' \
               --subst-var-by 'PGSQL_SUPERUSER' '${pgsqlSuperuser}' \
               --subst-var-by 'PSQL15_BINDIR' '${basePackages.psql_15.bin}'\
-              --subst-var-by 'PSQL16_BINDIR' '${basePackages.psql_16.bin}'
+              --subst-var-by 'PSQL16_BINDIR' '${basePackages.psql_16.bin}' \
+              --subst-var-by 'PSQLORIOLEDB16_BINDIR' '${basePackages.psql_orioledb_16.bin}'
             chmod +x $out/bin/start-postgres-client
           '';
 
@@ -417,6 +419,7 @@
               substitute ${./tools/migrate-tool.sh.in} $out/bin/migrate-postgres \
                 --subst-var-by 'PSQL15_BINDIR' '${basePackages.psql_15.bin}' \
                 --subst-var-by 'PSQL16_BINDIR' '${basePackages.psql_16.bin}' \
+                --subst-var-by 'PSQLORIOLEDB16_BINDIR' '${basePackages.psql_orioledb_16.bin}' \
                 --subst-var-by 'PSQL_CONF_FILE' '${configFile}' \
                 --subst-var-by 'PGSODIUM_GETKEY' '${getkeyScript}' \
                 --subst-var-by 'PRIMING_SCRIPT' '${primingScript}' \
@@ -430,7 +433,8 @@
             substitute ${./tools/run-replica.sh.in} $out/bin/start-postgres-replica \
               --subst-var-by 'PGSQL_SUPERUSER' '${pgsqlSuperuser}' \
               --subst-var-by 'PSQL15_BINDIR' '${basePackages.psql_15.bin}'\
-              --subst-var-by 'PSQL16_BINDIR' '${basePackages.psql_16.bin}'
+              --subst-var-by 'PSQL16_BINDIR' '${basePackages.psql_16.bin}' \
+              --subst-var-by 'PSQLORIOLEDB16_BINDIR' '${basePackages.psql_orioledb_16.bin}'
             chmod +x $out/bin/start-postgres-replica
           '';
         };
@@ -482,6 +486,7 @@
         checks = {
           psql_15 = makeCheckHarness basePackages.psql_15.bin;
           psql_16 = makeCheckHarness basePackages.psql_16.bin;
+          psql_orioledb_16 = makeCheckHarness basePackages.psql_orioledb_16.bin;
         };
 
         # Apps is a list of names of things that can be executed with 'nix run';

--- a/flake.nix
+++ b/flake.nix
@@ -75,12 +75,12 @@
           "pgjwt"
           "plpgsql_check"
           "pg_safeupdate"
-          /*"timescaledb"*/
           "wal2json"
           /* pljava */
           "rum"
           "pg_repack"
           "pgroonga"
+          "timescaledb"
         ];
 
         # Custom extensions that exist in our repository. These aren't upstream
@@ -112,8 +112,8 @@
           ./ext/supautils.nix
           ./ext/plv8.nix
         ];
-        #TODO add the orioledb extension
-        orioledbExtension = ourExtensions ++ [ ];
+
+        orioledbExtension = ourExtensions ++ [./ext/orioledb.nix ];
         # Create a 'receipt' file for a given postgresql package. This is a way
         # of adding a bit of metadata to the package, which can be used by other
         # tools to inspect what the contents of the install are: the PSQL

--- a/flake.nix
+++ b/flake.nix
@@ -419,7 +419,6 @@
               substitute ${./tools/migrate-tool.sh.in} $out/bin/migrate-postgres \
                 --subst-var-by 'PSQL15_BINDIR' '${basePackages.psql_15.bin}' \
                 --subst-var-by 'PSQL16_BINDIR' '${basePackages.psql_16.bin}' \
-                --subst-var-by 'PSQLORIOLEDB16_BINDIR' '${basePackages.psql_orioledb_16.bin}' \
                 --subst-var-by 'PSQL_CONF_FILE' '${configFile}' \
                 --subst-var-by 'PGSODIUM_GETKEY' '${getkeyScript}' \
                 --subst-var-by 'PRIMING_SCRIPT' '${primingScript}' \
@@ -433,8 +432,7 @@
             substitute ${./tools/run-replica.sh.in} $out/bin/start-postgres-replica \
               --subst-var-by 'PGSQL_SUPERUSER' '${pgsqlSuperuser}' \
               --subst-var-by 'PSQL15_BINDIR' '${basePackages.psql_15.bin}'\
-              --subst-var-by 'PSQL16_BINDIR' '${basePackages.psql_16.bin}' \
-              --subst-var-by 'PSQLORIOLEDB16_BINDIR' '${basePackages.psql_orioledb_16.bin}'
+              --subst-var-by 'PSQL16_BINDIR' '${basePackages.psql_16.bin}' 
             chmod +x $out/bin/start-postgres-replica
           '';
         };
@@ -466,6 +464,7 @@
 
             pkill postgres
             mv logfile $out
+            echo ${pgpkg}
           '';
 
       in

--- a/flake.nix
+++ b/flake.nix
@@ -113,7 +113,7 @@
           ./ext/plv8.nix
         ];
         #TODO add the orioledb extension
-        orioledbExtension = ourExtensions ++ [];
+        orioledbExtension = ourExtensions ++ [ ];
         # Create a 'receipt' file for a given postgresql package. This is a way
         # of adding a bit of metadata to the package, which can be used by other
         # tools to inspect what the contents of the install are: the PSQL

--- a/justfile
+++ b/justfile
@@ -11,6 +11,7 @@ alias c := check
 build-all:
     nix build .#psql_15/bin .#psql_15/docker
     nix build .#psql_16/bin .#psql_16/docker
+    nix build .#psql_orioledb_16/bin .#psql_orioledb_16/docker
 
 check:
     nix flake check -L

--- a/overlays/psql_16-oriole.nix
+++ b/overlays/psql_16-oriole.nix
@@ -1,23 +1,23 @@
-final: prev: { 
-            postgresql_16 = prev.postgresql_16.overrideAttrs (old: {
-              pname = "postgres_16";
-              version = "16.2";
-              src = prev.fetchurl  {
-                  url = "https://github.com/orioledb/postgres/archive/refs/tags/patches16_23.tar.gz";
-                sha256 = "sha256-xWmcqn3DYyBG0FsBNqPWTFzUidSJZgoPWI6Rt0N9oJ4=";
-                };
+final: prev: {
+  postgresql_16 = prev.postgresql_16.overrideAttrs (old: {
+    pname = "postgres_16";
+    version = "16.2";
+    src = prev.fetchurl {
+      url = "https://github.com/orioledb/postgres/archive/refs/tags/patches16_23.tar.gz";
+      sha256 = "sha256-xWmcqn3DYyBG0FsBNqPWTFzUidSJZgoPWI6Rt0N9oJ4=";
+    };
 
-              buildInputs =  old.buildInputs ++ [ 
-                prev.bison
-                prev.docbook5
-                prev.docbook_xsl
-                prev.docbook_xsl_ns
-                prev.docbook_xml_dtd_45
-                prev.flex
-                prev.libxslt
-                prev.perl 
-              ];
-              doCheck = true;
-            });
-            pg16_oriole = final.postgresql_16;
-          }
+    buildInputs = old.buildInputs ++ [
+      prev.bison
+      prev.docbook5
+      prev.docbook_xsl
+      prev.docbook_xsl_ns
+      prev.docbook_xml_dtd_45
+      prev.flex
+      prev.libxslt
+      prev.perl
+    ];
+    doCheck = true;
+  });
+  pg16_oriole = final.postgresql_16;
+}

--- a/overlays/psql_16-oriole.nix
+++ b/overlays/psql_16-oriole.nix
@@ -1,0 +1,23 @@
+final: prev: { 
+            postgresql_16 = prev.postgresql_16.overrideAttrs (old: {
+              pname = "postgres_16";
+              version = "16.2";
+              src = prev.fetchurl  {
+                  url = "https://github.com/orioledb/postgres/archive/refs/tags/patches16_23.tar.gz";
+                sha256 = "sha256-xWmcqn3DYyBG0FsBNqPWTFzUidSJZgoPWI6Rt0N9oJ4=";
+                };
+
+              buildInputs =  old.buildInputs ++ [ 
+                prev.bison
+                prev.docbook5
+                prev.docbook_xsl
+                prev.docbook_xsl_ns
+                prev.docbook_xml_dtd_45
+                prev.flex
+                prev.libxslt
+                prev.perl 
+              ];
+              doCheck = true;
+            });
+            pg16_oriole = final.postgresql_16;
+          }

--- a/overlays/psql_16-oriole.nix
+++ b/overlays/psql_16-oriole.nix
@@ -1,6 +1,6 @@
 final: prev: {
-  postgresql_16 = prev.postgresql_16.overrideAttrs (old: {
-    pname = "postgres_16";
+  postgresql_orioledb_16 = prev.postgresql_16.overrideAttrs (old: {
+    pname = "postgresql_16";
     version = "16.2";
     src = prev.fetchurl {
       url = "https://github.com/orioledb/postgres/archive/refs/tags/patches16_23.tar.gz";
@@ -19,5 +19,5 @@ final: prev: {
     ];
     doCheck = true;
   });
-  pg16_oriole = final.postgresql_16;
+  pg16_oriole = final.postgresql_orioledb_16;
 }

--- a/overlays/psql_16-oriole.nix
+++ b/overlays/psql_16-oriole.nix
@@ -1,12 +1,11 @@
 final: prev: {
-  postgresql_orioledb_16 = prev.postgresql_16.overrideAttrs (old: {
+  postgresql_16 = prev.postgresql_16.overrideAttrs (old: {
     pname = "postgresql_16";
-    version = "16.2";
+    version = "16_23";
     src = prev.fetchurl {
       url = "https://github.com/orioledb/postgres/archive/refs/tags/patches16_23.tar.gz";
       sha256 = "sha256-xWmcqn3DYyBG0FsBNqPWTFzUidSJZgoPWI6Rt0N9oJ4=";
     };
-
     buildInputs = old.buildInputs ++ [
       prev.bison
       prev.docbook5
@@ -17,7 +16,6 @@ final: prev: {
       prev.libxslt
       prev.perl
     ];
-    doCheck = true;
   });
-  pg16_oriole = final.postgresql_orioledb_16;
+  postgresql_orioledb_16 = final.postgresql_16;
 }

--- a/tools/run-client.sh.in
+++ b/tools/run-client.sh.in
@@ -5,15 +5,15 @@
 
 # first argument should be '15' or '16' for the version
 if [ "$1" == "15" ]; then
-    echo "Starting server for PSQL 15"
+    echo "Starting client for PSQL 15"
     PSQL15=@PSQL15_BINDIR@
     BINDIR="$PSQL15"
 elif [ "$1" == "16" ]; then
-    echo "Starting server for PSQL 16"
+    echo "Starting client for PSQL 16"
     PSQL16=@PSQL16_BINDIR@
     BINDIR="$PSQL16"
 elif [ "$1" == "orioledb-16" ]; then
-    echo "Starting server for PSQL ORIOLEDB 16"
+    echo "Starting client for PSQL ORIOLEDB 16"
     PSQLORIOLEDB16=@PSQLORIOLEDB16_BINDIR@
     BINDIR="$PSQLORIOLEDB16"
 else

--- a/tools/run-client.sh.in
+++ b/tools/run-client.sh.in
@@ -12,8 +12,12 @@ elif [ "$1" == "16" ]; then
     echo "Starting server for PSQL 16"
     PSQL16=@PSQL16_BINDIR@
     BINDIR="$PSQL16"
+elif [ "$1" == "orioledb-16" ]; then
+    echo "Starting server for PSQL ORIOLEDB 16"
+    PSQLORIOLEDB16=@PSQLORIOLEDB16_BINDIR@
+    BINDIR="$PSQLORIOLEDB16"
 else
-    echo "Please provide a valid Postgres version (15 or 16)"
+    echo "Please provide a valid Postgres version (15, 16, or orioledb-16)"
     exit 1
 fi
 

--- a/tools/run-replica.sh.in
+++ b/tools/run-replica.sh.in
@@ -12,8 +12,12 @@ elif [ "$1" == "16" ]; then
     echo "Starting server for PSQL 16"
     PSQL16=@PSQL16_BINDIR@
     BINDIR="$PSQL16"
+elif [ "$1" == "orioledb-16" ]; then
+    echo "Starting server for PSQL ORIOLEDB 16"
+    PSQLORIOLEDB16=@PSQLORIOLEDB16_BINDIR@
+    BINDIR="$PSQLORIOLEDB16"
 else
-    echo "Please provide a valid Postgres version (15 or 16)"
+    echo "Please provide a valid Postgres version (15, 16 or orioledb-16)"
     exit 1
 fi
 

--- a/tools/run-server.sh.in
+++ b/tools/run-server.sh.in
@@ -12,8 +12,12 @@ elif [ "$1" == "16" ]; then
     echo "Starting server for PSQL 16"
     PSQL16=@PSQL16_BINDIR@
     BINDIR="$PSQL16"
+elif [ "$1" == "orioledb-16" ]; then
+    echo "Starting server for PSQL ORIOLEDB 16"
+    PSQLORIOLEDB16=@PSQLORIOLEDB16_BINDIR@
+    BINDIR="$PSQLORIOLEDB16"
 else
-    echo "Please provide a valid Postgres version (15 or 16)"
+    echo "Please provide a valid Postgres version (15, 16 or orioledb-16)"
     exit 1
 fi
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

This branch imports and builds the upstream https://github.com/orioledb/postgres/tree/patches16_23 patched source for psql 16

It also optionally downloads and compiles the https://github.com/orioledb/orioledb psql extension against the patched version of psql 16

There is now a `psql_orioledb_16/bin`  and `psql_orioledb_16/docker` plus a set of extensions built against `psql_orioledb_16/bin`

we have retained `psql_16/bin` and `psql_15/bin` and docker image builds, tests as well.

This PR will remain in draft form until some issues listed below are ironed out
