### PR TITLE
feat: update oriole sources

### DIFF
--- a/ext/orioledb.nix
+++ b/ext/orioledb.nix
@@ -6,12 +6,12 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "orioledb";
     repo = "orioledb";
-    rev = "main";
-    sha256 = "sha256-QbDp9S8JXO66sfaHZIQ3wFCVRxsAaaNSRgC6hvL3EKY=";
+    rev = "bump-patchset-version-2";
+    sha256 = "sha256-O8AJcl7/WYTesY/46Vl9CTtbJqz/xOMN5CNajwOChrc=";
   };
-  version = "patches16_23";
+  version = "patches16_24";
   buildInputs = [ curl libkrb5 postgresql python3 openssl ];
-  buildPhase = "make USE_PGXS=1 ORIOLEDB_PATCHSET_VERSION=23";
+  buildPhase = "make USE_PGXS=1 ORIOLEDB_PATCHSET_VERSION=24";
   installPhase = ''
     runHook preInstall
     mkdir -p $out/{lib,share/postgresql/extension}

--- a/flake.nix
+++ b/flake.nix
@@ -118,7 +118,7 @@
           "rum"
           "pg_repack"
           "pgroonga"
-          /*"timescaledb"*/
+          "timescaledb"
         ];
 
         # Custom extensions that exist in our repository. These aren't upstream
@@ -417,7 +417,7 @@
           # PostgreSQL versions.
           psql_15 = makePostgres "15";
           psql_16 = makePostgres "16";
-          psql_orioledb_16 = makeOrioleDbPostgres "16_23" postgresql_orioledb_16;
+          psql_orioledb_16 = makeOrioleDbPostgres "16_24" postgresql_orioledb_16;
 
           # Start a version of the server.
           start-server =

--- a/overlays/psql_16-oriole.nix
+++ b/overlays/psql_16-oriole.nix
@@ -1,10 +1,10 @@
 final: prev: {
   postgresql_16 = prev.postgresql_16.overrideAttrs (old: {
     pname = "postgresql_16";
-    version = "16_23";
+    version = "16_24";
     src = prev.fetchurl {
-      url = "https://github.com/orioledb/postgres/archive/refs/tags/patches16_23.tar.gz";
-      sha256 = "sha256-xWmcqn3DYyBG0FsBNqPWTFzUidSJZgoPWI6Rt0N9oJ4=";
+      url = "https://github.com/orioledb/postgres/archive/refs/heads/patches16-tableam-compat-2.tar.gz";
+      sha256 = "sha256-CoUSk+sWJ3OEzfDqQWS9kG6HK5D4vQiGbLURazCceNU=";
     };
     buildInputs = old.buildInputs ++ [
       prev.bison


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR applies the patched sources at 

https://github.com/orioledb/orioledb/tree/bump-patchset-version-2
https://github.com/orioledb/postgres/tree/patches16-tableam-compat-2

There is actually still an issue with the timescaledb build on these new sources, but I wanted to see what the stack trace is in gh actions to make it simpler to share and see what the problem is by just viewing action output/re-running it. 
