### PR TITLE
fix: include orioledb_16 in cache upload on pr merge to main

### DIFF
--- a/.github/workflows/cache-upload.yml
+++ b/.github/workflows/cache-upload.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: build and copy to S3
         run: |
-          for x in 15 16; do
+          for x in 15 16 orioledb_16; do
             nix build .#psql_$x/bin -o result-$x
           done
           nix copy --to s3://nix-postgres-artifacts?secret-key=nix-secret-key ./result*


### PR DESCRIPTION
## What kind of change does this PR introduce?

cache upload needed to include build for `orioledb_16`